### PR TITLE
Sync open API changes with backend HTTPS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ generator_tools/docs/
 
 # alembic
 alembic.ini
+
+openapi/ssl/

--- a/main.py
+++ b/main.py
@@ -35,6 +35,10 @@ app.add_middleware(
         "http://localhost:8082",
         "http://127.0.0.1:8080",
         "http://localhost:5173",
+        "http://10.0.2.2:8080",  # ✅ Додай це
+        "http://10.0.2.2:5173",  # ✅ І це (якщо фронт працює на цьому порту)
+        "capacitor://localhost",
+        "https://localhost",
     ],  # 👈 дозволяє фронтенду
     allow_credentials=True,
     allow_methods=["*"],
@@ -60,3 +64,16 @@ app.include_router(ping_router)
 @app.get("/openapi")
 def open_root():
     return {"message": "Публічний інтерфейс"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "openapi.main:app",
+        host="0.0.0.0",  # nosec B104
+        port=8000,
+        ssl_keyfile="ssl/key.pem",
+        ssl_certfile="ssl/cert.pem",
+        reload=True,
+    )


### PR DESCRIPTION
Summary:

This PR updates the public API layer to reflect changes made in the private backend, where HTTPS support has been added for local development and emulator testing.

Note:

Docker-related or SSL files are managed in the private repo.

This update is purely structural and keeps public API routes in sync with current development status.
_________________________________________________________________________________

Заголовок: Синхронізація відкритих API-змін із приватною підтримкою HTTPS

Коротко:

Цей пул-реквест оновлює відкритий репозиторій відповідно до змін у приватному, де додано підтримку HTTPS для локальної розробки та роботи з емулятором.

Примітка:

Усі файли Docker та SSL знаходяться у приватному репозиторії.

Ці зміни — структурні, вони дозволяють тримати відкритий код у актуальному стані.